### PR TITLE
Per-page reload opt-out (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,22 @@ module.exports = {
 }
 ```
 
+To prevent a single page from automatically reloading, add `data-server-no-reload` to the `<body>` tag:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+    ...
+</head>
+<body data-server-no-reload>
+  ...
+</body>
+</html>
+```
+
+This will omit the usually injected Javascript from being instantiated on that given page.
+
 ### Browser of your choice
 
 The option browser can be a `string` or an `string[]`.  

--- a/client/injected.ts
+++ b/client/injected.ts
@@ -7,7 +7,12 @@ import { appendPathToUrl } from '../src/helpers'
 // manipulates it inside window.addEventListener('load', (...))
 let _internalDOMBody
 
-if ('WebSocket' in window) {
+const block = document.body.hasAttribute('data-server-no-reload');
+
+if (block) {
+  console.info('[Five Server] Reload disabled due to \'data-server-no-reload\' attribute on BODY element')
+}
+if ('WebSocket' in window && !block) {
   window.addEventListener('load', () => {
     console.log('[Five Server] connecting...')
 


### PR DESCRIPTION
If the attribute `data-server-no-reload` is found on the BODY tag, the client-side injection is omitted.